### PR TITLE
Do not check if "_actions" exists in object

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -28,7 +28,7 @@ const makeInvokeAction = ({ strict = false } = {}) => {
 };
 
 const getActions = (object) => {
-  return object._actions ? object._actions : object.actions;
+  return object.actions ? object.actions : object._actions;
 };
 
 const makeInvoke = ({ strict = false } = {}) => {


### PR DESCRIPTION
This fixes deprecation warning: https://github.com/emberjs/ember.js/pull/12028 and leaves backward compatibility for some ancient versions of Ember

Fixes issue: https://github.com/martndemus/ember-invoke-action/issues/6